### PR TITLE
Improve processing speed

### DIFF
--- a/agol_connection.py
+++ b/agol_connection.py
@@ -65,9 +65,10 @@ class AGOLConnection(object):
 
     def overwrite_arcgis_layer(self, dataset_name, source_data_dir, source_data_file, dry_run=False):
 
-        print(f"Begin upload to ArcGIS Online")
-        if dry_run is True and self.verbose:
-            print("** DRY RUN -- NO UPLOAD WILL HAPPEN **")
+        if self.verbose:
+            print(f"Begin upload to ArcGIS Online")
+            if dry_run is True:
+                print("** DRY RUN -- NO UPLOAD WILL HAPPEN **")
 
         try:
             layer_config = self.layers[dataset_name]
@@ -116,7 +117,8 @@ class AGOLConnection(object):
                 if self.verbose:
                     print("        finished.")
             else:
-                result = "Dry run complete"
+                if self.verbose:
+                    result = "Dry run complete"
             os.chdir(original_dir)
         return result
 

--- a/agol_connection.py
+++ b/agol_connection.py
@@ -17,7 +17,8 @@ class AGOLConnection(object):
 
         self.creds = creds
         self.layers = self._get_layers()
-        self.gis = self._get_gis()
+        self.gis = self._make_connection()
+        self.verbose = verbose
 
     def _load_credentials(self):
 
@@ -42,7 +43,7 @@ class AGOLConnection(object):
 
         return configs
 
-    def _get_gis(self):
+    def _make_connection(self):
         username = self.creds['username']
         password = self.creds['password']
         host = self.creds['host']

--- a/header_mapping.py
+++ b/header_mapping.py
@@ -51,6 +51,19 @@ class HeaderMapping(object):
 
         return self.get_fieldnames() + self.get_aliases()
 
+    def get_master_lookup(self):
+        """This lookup has keys for all long names AND all short names. Each key
+        corresponds to the proper short name. Allows a single point of entry for
+        any header name."""
+
+        lookup = {}
+        for k, v in self.mapping.items():
+            lookup[k] = k
+            for alias in v:
+                lookup[alias] = k
+
+        return lookup
+
 
 ltc_mapping = {}
 

--- a/ingester.py
+++ b/ingester.py
@@ -63,7 +63,7 @@ def create_summary_table_row(df, source_data_timestamp, source_filename):
 
 class Ingester(object):
 
-    def __init__(self, dry_run=False):
+    def __init__(self, dry_run=False, verbose=False):
 
         creds = self._load_credentials()
         if creds is None:
@@ -74,6 +74,7 @@ class Ingester(object):
         agol_connection = AGOLConnection()
         self.agol = agol_connection
         self.available_files = []
+        self.verbose = verbose
 
     def _load_credentials(self):
 
@@ -92,7 +93,7 @@ class Ingester(object):
         return creds
 
     def get_files_from_sftp(self, prefix="HOS_ResourceCapacity_", target_dir="/tmp",
-                                   only_latest=True, filenames_to_ignore=[]):
+                                   only_latest=True, filenames_to_ignore=[], verbose=False):
 
         cnopts = pysftp.CnOpts()
         cnopts.hostkeys.load('copaftp.pub')
@@ -119,14 +120,18 @@ class Ingester(object):
                 files_to_get = files
             for f in files_to_get:
                 if f in filenames_to_ignore:
-                    print(f"Ignoring {f}")
+                    if self.verbose:
+                        print(f"Ignoring {f}")
                     continue
-                print(f"Getting: {f}")
+                if self.verbose:
+                    print(f"Getting: {f}")
                 if os.path.join(target_dir, f) not in existing_files:
                     sftp.get(f, f'{target_dir}/{f}')
-                    print(f"Finished downloading {target_dir}/{f}")
+                    if self.verbose:
+                        print(f"Finished downloading {target_dir}/{f}")
                 else:
-                    print(f"Didn't have to download {target_dir}/{f}; it already exists")
+                    if self.verbose:
+                        print(f"Didn't have to download {target_dir}/{f}; it already exists")
 
                 source_date = get_datetime_from_filename(f, prefix=prefix)
                 file_details.append({"dir": target_dir, "filename": f, "source_datetime": source_date})

--- a/ingester.py
+++ b/ingester.py
@@ -149,16 +149,19 @@ class Ingester(object):
         else:
             dataset_name = "hospital_layer"
 
-        print(f"Starting load of hospital data: {dataset_name}")
+        if self.verbose:
+            print(f"Starting load of hospital data: {dataset_name}")
 
         status = self.agol.overwrite_arcgis_layer(dataset_name, processed_dir, processed_filename, dry_run=self.dry_run)
 
-        print(status)
-        print(f"Finished load of hospital data: {dataset_name}")
+        if self.verbose:
+            print(status)
+            print(f"Finished load of hospital data: {dataset_name}")
         return processed_dir, processed_filename
 
     def process_supplies(self, processed_dir, processed_filename):
-        print("Starting load of supplies data")
+        if self.verbose:
+            print("Starting load of supplies data")
 
         # set the new file name using the original file name in the layers conf
         supplies_filename = self.agol.layers['supplies']['original_file_name']
@@ -169,12 +172,15 @@ class Ingester(object):
         supplies.to_csv(os.path.join(processed_dir, supplies_filename), index=False)
 
         status = self.agol.overwrite_arcgis_layer("supplies", processed_dir, supplies_filename, dry_run=self.dry_run)
-        print(status)
-        print("Finished load of supplies data")
+
+        if self.verbose:
+            print(status)
+            print("Finished load of supplies data")
 
     def process_county_summaries(self, processed_dir, processed_filename):
 
-        print("Starting load of county summary table...")
+        if self.verbose:
+            print("Starting load of county summary table...")
 
         new_data_filename = "new_county_summary_table.csv"
 
@@ -198,11 +204,15 @@ class Ingester(object):
         d2.to_csv(os.path.join(processed_dir, new_data_filename), header=True, index=False)
 
         status = self.agol.overwrite_arcgis_layer("county_summaries", processed_dir, new_data_filename, dry_run=self.dry_run)
-        print(status)
-        print("Finished load of county summary data")
+
+        if self.verbose:
+            print(status)
+            print("Finished load of county summary data")
 
     def process_summaries(self, processed_dir, processed_file_details, make_historical_csv=False):
-        print("Starting load of summary table...")
+
+        if self.verbose:
+            print("Starting load of summary table...")
 
         summary_filename = self.agol.layers['summary_table']['original_file_name']
 
@@ -220,7 +230,8 @@ class Ingester(object):
         if make_historical_csv:
             out_csv_file = os.path.join(processed_dir, summary_filename)
             summary_df.to_csv(out_csv_file, index=False, header=True)
-            print("Finished creation of historical summary table CSV, returning.")
+            if self.verbose:
+                print("Finished creation of historical summary table CSV, returning.")
             return
 
         layer_conf = self.agol.layers['summary_table']
@@ -244,17 +255,20 @@ class Ingester(object):
         # but it won't stop the processing.
         fs = FeatureSet(features)
         if self.dry_run:
-            print("Dry run set, not editing features.")
-            status = "Dry run"
+            if self.verbose:
+                print("Dry run set, not editing features.")
         else:
             status = t.edit_features(adds=features)
-        print(status)
-        print("Finished load of summary table")
+            if self.verbose:
+                print(status)
+        if self.verbose:
+            print("Finished load of summary table")
 
 
     def process_historical_hos(self, processed_dir, processed_file_details,  make_historical_csv=False):
 
-        print("Starting load of historical HOS table...")
+        if self.verbose:
+            print("Starting load of historical HOS table...")
 
         layer_conf = self.agol.layers['full_historical_table']
         original_data_file_name = layer_conf['original_file_name']
@@ -319,18 +333,21 @@ class Ingester(object):
         features = [Feature(attributes=row) for row in hist_csv_rows]
         fs = FeatureSet(features)
         if self.dry_run:
-            print("Dry run set, not editing features.")
+            if self.verbose:
+                print("Dry run set, not editing features.")
         else:
             fc = len(features)
             chunksize = 1000.0
             feature_batchs = chunks(features, math.ceil(fc / chunksize))
             fb_list = list(feature_batchs)
             fbc = len(fb_list)
-            print(f"Adding {fc} features to the historical table in {fbc} batches.")
+            if self.verbose:
+                print(f"Adding {fc} features to the historical table in {fbc} batches.")
             for batch in fb_list:
                 status = t.edit_features(adds=batch)
                 print(status)
-        print("Finished load of historical HOS table")
+        if self.verbose:
+            print("Finished load of historical HOS table")
 
     def process_daily_hospital_averages(self, historical_gis_item_id, daily_averages_item_id):
         # see what days have been processed

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import argparse
+from datetime import datetime
 
 import header_mapping as hm
 from operators import process_csv
@@ -9,8 +10,10 @@ from validator import CSVValidator
 from ingester import Ingester
 
 
-    print("Processing instantaneous tables...")
 def process_instantaneous(dry_run=False, datadir=None, verbose=False):
+
+    start = datetime.now()
+    print("\nSTARTING process_instantaneous()")
 
     if datadir is None:
         datadir = "/tmp"
@@ -21,21 +24,25 @@ def process_instantaneous(dry_run=False, datadir=None, verbose=False):
     # should be done to consolidate the sftp and file management process.
     # the only difference is that now Ingester().get_files_from_sftp() is used.
     print("Getting latest HOS file from SFTP...")
+    a = datetime.now()
     file_details, all_filenames = ingester.get_files_from_sftp(target_dir=datadir)
-    print("Finished.")
+    print(f"Finished: {datetime.now() - a}")
 
     latest_file_details = file_details[0]
 
     # run a validation on the latest file (the one that will be used for instantaneous)
     # validate_csv() will raise an exception if it fails. use raise_exception=False
     # to run it quietly.
+    a = datetime.now()
     v = CSVValidator("HOS")
     fpath = os.path.join(latest_file_details['dir'], latest_file_details['filename'])
     v.validate_csv(fpath)
+    print(f"latest CSV validated: {datetime.now() - a}")
 
     # validation passed on downloaded file, now do all processing
 
     # Public-only data
+    a = datetime.now()
     public_processed_file_details = process_csv(
         [latest_file_details],
         output_prefix="public_processed_HOS_",
@@ -44,12 +51,15 @@ def process_instantaneous(dry_run=False, datadir=None, verbose=False):
     )
     public_processed_filename = public_processed_file_details[0]["processed_filename"]
     public_processed_dir = public_processed_file_details[0]["output_dir"]
+    print(f"processed latest CSV (only public columns): {datetime.now() - a}")
 
     # Full data
+    a = datetime.now()
     processed_file_details = process_csv(
         [latest_file_details],
         output_dir=datadir
     )
+    print(f"processed latest CSV (full): {datetime.now() - a}")
 
     processed_filename = processed_file_details[0]["processed_filename"]
     processed_dir = processed_file_details[0]["output_dir"]
@@ -57,50 +67,78 @@ def process_instantaneous(dry_run=False, datadir=None, verbose=False):
     print(f"Finished processing {datadir}/{latest_file_details['filename']}, file is {processed_dir}/{processed_filename}")
 
     # process csv to update the non-public hospital table
+    a = datetime.now()
     ingester.process_hospital(processed_dir, processed_filename, public=False)
+    print(f"process hospital (full): {datetime.now() - a}")
 
     # process csv to update the public hospital table
+    a = datetime.now()
     ingester.process_hospital(public_processed_dir, public_processed_filename)
+    print(f"process hospital (public): {datetime.now() - a}")
 
     # process supplies
+    a = datetime.now()
     ingester.process_supplies(processed_dir, processed_filename)
+    print(f"process supplies: {datetime.now() - a}")
 
+    a = datetime.now()
     ingester.process_county_summaries(processed_dir, processed_filename)
-    print("Finished processing instantaneous tables.")
+    print(f"process county summaries: {datetime.now() - a}")
+    print(f"FINISHED process_instantaneous(): {datetime.now() - start}")
 
 def process_historical(dry_run=False, datadir=None, make_historical_csv=False, verbose=False):
 
+    print("\nSTARTING process_historical()")
+    start = datetime.now()
     if datadir is None:
         datadir = "/tmp"
 
     ingester = Ingester(dry_run, verbose=verbose)
 
-    files_to_not_sftp = ingester.gis.get_already_processed_files("summary_table")
+    a = datetime.now()
+    files_to_not_sftp = ingester.get_already_processed_files("summary_table")
+    print(f"determined already processed files (summary_table): {datetime.now() - a}")
+
+    a = datetime.now()
     file_details, all_filenames = ingester.get_files_from_sftp(target_dir=datadir, only_latest=False, filenames_to_ignore=files_to_not_sftp)
+    print(f"downloaded files: {datetime.now() - a}")
 
     if len(file_details) == 0:
-        print("No new files to process for historical summary table data.")
+        print("  No new files to process for historical summary table data.")
     else:
+        a = datetime.now()
         processed_file_details = process_csv(file_details, output_dir=datadir)
+        print(f"process_csv(): {datetime.now() - a}")
         processed_dir = processed_file_details[0]["output_dir"]
+        a = datetime.now()
         ingester.process_summaries(processed_dir, processed_file_details, make_historical_csv=make_historical_csv)
+        print(f"process_summaries(): {datetime.now() - a}")
 
-    files_to_not_sftp = ingester.gis.get_already_processed_files("full_historical_table")
+    a = datetime.now()
+    files_to_not_sftp = ingester.get_already_processed_files("full_historical_table")
+    print(f"determined already processed files (full_historical_table): {datetime.now() - a}")
+
 
     if make_historical_csv:
         # setting files_to_not_sftp to an empty list ensures we rebuild the full historical table
         files_to_not_sftp = []
 
+    a = datetime.now()
     file_details, all_filenames = ingester.get_files_from_sftp(target_dir=datadir, only_latest=False, filenames_to_ignore=files_to_not_sftp)
+    print(f"downloaded files: {datetime.now() - a}")
+
     if len(file_details) == 0:
-        print("No new files to process for historical data.")
+        print("  No new files to process for historical data.")
     else:
+        a = datetime.now()
         processed_file_details = process_csv(file_details, output_dir=datadir)
+        print(f"process_csv(): {datetime.now() - a}")
         processed_dir = processed_file_details[0]["output_dir"]
+        a = datetime.now()
         ingester.process_historical_hos(processed_dir, processed_file_details, make_historical_csv=make_historical_csv)
+        print(f"process_historical_hos: {datetime.now() - a}")
 
-
-    print("Finished processing historical tables.")
+    print(f"FINISHED process_historical(): {datetime.now()-start}")
 
 
 def process_canary_features(dry_run=False, datadir=None, verbose=False):
@@ -109,8 +147,6 @@ def process_canary_features(dry_run=False, datadir=None, verbose=False):
         datadir = "/tmp"
 
     ingester = Ingester(dry_run, verbose=verbose)
-    agol_connection = AGOLConnection()
-    ingester.set_gis(agol_connection)
 
     print("XXX not doing historical averages yet")
     historical_gis_item_id = "3b39827f6f804c33b9b1114b5aa1d6b6" # v4
@@ -142,12 +178,9 @@ if __name__== "__main__":
     parser.add_argument("--make_historical_csv", action="store_true")
     parser.add_argument("--quiet", action="store_true")
     args = parser.parse_args()
-    if args.dry_run is not None:
-        dry_run = True
-    if args.make_historical_csv is not None:
-        make_historical_csv = True
-    print(f"dry_run: {dry_run}")
-    main(dry_run, datadir=args.dir, make_historical_csv=make_historical_csv)
+
+    print(f"dry_run: {args.dry_run}")
+
     # note that the cli argument is --quiet but from here on the argument passed around is "verbose"
     verbose = not args.quiet
     main(args.dry_run, datadir=args.dir, make_historical_csv=args.make_historical_csv, verbose=verbose)


### PR DESCRIPTION
This pull request implements the following:

- improve the way the ArcGIS connection is connected to Ingester()
- add a new method to HeaderMapping that constructs one lookup for headers to rule them all
- cut down the logic used for header matching in process_historical_hos and in process_csv (this is the actual thing that improves performance
- add a bunch of timing print statements in main.py to inspect performance more closely
- streamline boolean command line flags in main.py and add `--quiet` that silences _all_ print statements besides those timing ones mentioned above

Though it's somewhat hard to mock up real timing while running dry runs, these improvements should cut down the process_historical() operation from ~34 seconds to ~19.